### PR TITLE
Fix bug for not finding venv in parents dir

### DIFF
--- a/pkg/virtenv/path.go
+++ b/pkg/virtenv/path.go
@@ -36,9 +36,14 @@ func absPathContains(src string, target string) bool {
 	return false
 }
 
-func searchScriptRecursively(cwd string, venvDirs []string, script string) string {
+func searchScriptRecursively(cwd string, venvDirsBase []string, script string) string {
 	// We don't want errors on non existing script for some reason
 	for len(cwd) > 1 {
+		infra.DebugLog("CWD: " + cwd)
+		venvDirs := cwdCombinations(cwd, venvDirsBase)
+		infra.DebugLog(
+			fmt.Sprintf("Searching for script %s in venv dirs: %v", script, venvDirs),
+		)
 		for _, vd := range venvDirs {
 			scriptPath := filepath.Join(cwd, vd, script)
 			if _, err := os.Stat(scriptPath); err == nil {

--- a/pkg/virtenv/venv.go
+++ b/pkg/virtenv/venv.go
@@ -64,9 +64,7 @@ func GetCommand(venvDirs []string) string {
 	venv := getVenv()
 	infra.DebugLog(fmt.Sprintf("Venv status: %v", venv))
 
-	venvDirsProduct := cwdCombinations(cwd, venvDirs)
-
-	script := searchScriptRecursively(cwd, venvDirsProduct, activateScript)
+	script := searchScriptRecursively(cwd, venvDirs, activateScript)
 
 	return getCommandOnVenv(venv, cwd, script)
 }

--- a/pkg/virtenv/venv_test.go
+++ b/pkg/virtenv/venv_test.go
@@ -1,6 +1,8 @@
 package virtenv
 
-import "testing"
+import (
+	"testing"
+)
 
 type getCommandOnVenvTestCase struct {
 	name     string
@@ -24,6 +26,13 @@ var getCommandOnVenvCases = []getCommandOnVenvTestCase{
 		cwd:      "",
 		script:   "/foo/bar",
 		expected: "source '/foo/bar'",
+	},
+	{
+		name:     "not active parent with script",
+		venv:     Venv{false, "/foo/bar"},
+		cwd:      "/foo/baz",
+		script:   "/foo/bar/activate",
+		expected: "source '/foo/bar/activate'",
 	},
 	{
 		name:     "active nonsense path",


### PR DESCRIPTION
Checkin venv dirs combinations in `searchScriptRecursively`